### PR TITLE
Move styles from JavaScript file to CSS file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@
 
 include src/mkdocs_pagetree_plugin/js/*.js
 include src/mkdocs_pagetree_plugin/templates/*.j2
+include src/mkdocs_pagetree_plugin/css/*.css

--- a/src/mkdocs_pagetree_plugin/css/mkdocs_pagetree_plugin.css
+++ b/src/mkdocs_pagetree_plugin/css/mkdocs_pagetree_plugin.css
@@ -1,0 +1,49 @@
+/* Reset some default MkDocs styles */
+.pagetree details {
+  margin: 0;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+}
+/* Reset some Material for MkDocs styles */
+.md-typeset .pagetree details {
+  background-color: transparent;
+  border: none;
+  box-shadow: none;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.md-typeset .pagetree summary {
+  padding-left: 3em;
+  padding-top: 0;
+  padding-bottom: 0;
+  background-color: transparent;
+}
+.md-typeset .pagetree summary::after {
+  display: none;
+}
+.md-typeset .pagetree summary::before {
+  background-color: currentcolor;
+  content: "";
+  height: 1rem;
+  -webkit-mask-image: var(--md-details-icon);
+  mask-image: var(--md-details-icon);
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  position: absolute;
+  top: 0.1em;
+  left: 1.3em;
+  transform: rotate(0deg);
+  transition: transform 0.25s;
+  width: 1rem;
+}
+.md-typeset .pagetree details[open] > summary::before {
+  transform: rotate(90deg);
+}
+.md-typeset .pagetree-container ul li {
+  margin-bottom: 0;
+}

--- a/src/mkdocs_pagetree_plugin/js/mkdocs_pagetree_plugin.js
+++ b/src/mkdocs_pagetree_plugin/js/mkdocs_pagetree_plugin.js
@@ -3,67 +3,6 @@
 // SPDX-License-Identifier: MIT
 
 /**
-* Insert pagetree plugin CSS
-*/
-function insertCSS () {
-  const style = document.createElement('style')
-  style.appendChild(document.createTextNode(`
-  /* Reset some default MkDocs styles */
-  .pagetree details {
-    margin: 0;
-    padding: 0;
-    border: none;
-    background-color: transparent;
-  }
-  /* Reset some Material for MkDocs styles */
-  .md-typeset .pagetree details {
-    background-color: transparent;
-    border: none;
-    box-shadow: none;
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-  .md-typeset .pagetree summary {
-    padding-left: 3em;
-    padding-top: 0;
-    padding-bottom: 0;
-    background-color: transparent;
-  }
-  .md-typeset .pagetree summary::after {
-    display: none;
-  }
-  .md-typeset .pagetree summary::before {
-    background-color: currentcolor;
-    content: "";
-    height: 1rem;
-    -webkit-mask-image: var(--md-details-icon);
-    mask-image: var(--md-details-icon);
-    -webkit-mask-position: center;
-    mask-position: center;
-    -webkit-mask-repeat: no-repeat;
-    mask-repeat: no-repeat;
-    -webkit-mask-size: contain;
-    mask-size: contain;
-    position: absolute;
-    top: .1em;
-    left: 1.3em;
-    transform: rotate(0deg);
-    transition: transform .25s;
-    width: 1rem;
-  }
-  .md-typeset .pagetree details[open] > summary::before {
-    transform: rotate(90deg);
-  }
-  .md-typeset .pagetree-container ul li {
-    margin-bottom: 0;
-  }
-  `))
-
-  const head = document.getElementsByTagName('head')[0]
-  head.appendChild(style)
-}
-
-/**
 * Collapse/expand all pagetree <details> sections
 */
 function toggleDetails (pagetree, state) {
@@ -171,7 +110,6 @@ document.addEventListener('DOMContentLoaded', function (event) {
   const pagetreeFunctionsElement = pagetreeContainerElement.querySelector('.pagetree-functions')
   const pagetreeElement = pagetreeContainerElement.querySelector('.pagetree')
 
-  insertCSS()
   insertCollapseExpandButton(pagetreeContainerElement, pagetreeElement, pagetreeFunctionsElement)
   insertPageStatusFilter(pagetreeContainerElement, pagetreeElement, pagetreeFunctionsElement)
 })

--- a/src/mkdocs_pagetree_plugin/plugin.py
+++ b/src/mkdocs_pagetree_plugin/plugin.py
@@ -97,6 +97,7 @@ class PagetreePlugin(BasePlugin):
         config["extra_javascript"] = ["js/mkdocs_pagetree_plugin.js"] + config[
             "extra_javascript"
         ]
+        config["extra_css"] = ["css/mkdocs_pagetree_plugin.css"] + config["extra_css"]
         return config
 
     def on_post_build(self, config):
@@ -106,8 +107,13 @@ class PagetreePlugin(BasePlugin):
         # Using this weird js filename to avoid a clash with js files
         # named identically from other plugins/themes.
         module_name = "mkdocs_pagetree_plugin"
-        file = f"js/{module_name}.js"
-        current_dir = Path(__file__).parent
-        src_file_path = current_dir / file
-        dest_file_path = Path(config["site_dir"], file)
-        copy_file(src_file_path, dest_file_path)
+        files = [
+            f"js/{module_name}.js",
+            f"css/{module_name}.css",
+        ]
+
+        for f in files:
+            current_dir = Path(__file__).parent
+            src_file_path = current_dir / f
+            dest_file_path = Path(config["site_dir"], f)
+            copy_file(src_file_path, dest_file_path)


### PR DESCRIPTION
Hello,

I've been looking for this kind of plugin for my documentation pages. However, when I tried it out, the page tree "flickers" with the default admonition style for a split second, and only after that, the tree displays correct styles. I'm using the Material for MkDocs theme.

I looked into it and saw that the CSS classes are injected via the JS file. After moving them to a separate file, the issue was fixed. Is there a reason why the styles were in the JS file, e.g., caching issues?

I'm happy to make any requested changes, if required. Happy holidays!